### PR TITLE
Fix incorrect required from no to yes inventory organization

### DIFF
--- a/roles/inventories/README.md
+++ b/roles/inventories/README.md
@@ -81,7 +81,7 @@ The role will strip the double space between the curly bracket in order to provi
 |`name`|""|yes|str|Name of this inventory.|
 |`copy_from`|""|no|str|Name or id to copy the inventory from. This will copy an existing inventory and change any parameters supplied.|
 |`description`|""|no|str|Description of this inventory.|
-|`organization`|""|no|str|Organization this inventory belongs to.|
+|`organization`|""|yes|str|Organization this inventory belongs to.|
 |`instance_groups`|""|no|list|list of Instance Groups for this Inventory to run on.|
 |`variables`|`{}`|no|dict|Variables for the inventory.|
 |`kind`|""|no|str|The kind of inventory. Currently choices are '' and 'smart'|


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->

# What does this PR do?

Fix incorrect variable documentation for role inventories
`organization` is mandatory but documented as optional

# How should this be tested?

Call `inventories` role with: 

```
controller_inventories:

  - name: Workshop Inventory

```
# Is there a relevant Issue open for this?

Where are issues tracked? Not on github

# Other Relevant info, PRs, etc

